### PR TITLE
localize the tooltip variable to keep the tooltips localized to the proper RadarChart when multiple are on the page

### DIFF
--- a/src/radar-chart.js
+++ b/src/radar-chart.js
@@ -28,6 +28,8 @@ var RadarChart = {
     d3.select(id).select("svg").remove();
     var g = d3.select(id).append("svg").attr("width", cfg.w).attr("height", cfg.h).append("g");
 
+    var tooltip;
+
     for(var j=0; j<cfg.levels; j++){
       var levelFactor = cfg.factor*radius*((j+1)/cfg.levels);
       g.selectAll(".levels").data(allAxis).enter().append("svg:line")


### PR DESCRIPTION
Currently, the tooltips all appear on the last graph on the page instead of on the graph they belong to, which is disorienting.
