### PR TITLE
fixed a few small inconsistencies/inefficiencies

### DIFF
--- a/src/radar-chart.js
+++ b/src/radar-chart.js
@@ -60,7 +60,7 @@ var RadarChart = {
  
     d.forEach(function(y, x){
       dataValues = [];
-      d3.select(id+" g").selectAll(".nodes")
+      g.selectAll(".nodes")
         .data(y, function(j, i){
           dataValues.push([
             cfg.w/2*(1-(parseFloat(Math.max(j.value, 0))/cfg.maxValue)*cfg.factor*Math.sin(i*cfg.radians/total)), 
@@ -68,7 +68,7 @@ var RadarChart = {
           ]);
         });
       dataValues.push(dataValues[0]);
-      g.select(id+" g").selectAll(".area")
+      g.selectAll(".area")
                      .data([dataValues])
                      .enter()
                      .append("polygon")
@@ -98,7 +98,7 @@ var RadarChart = {
 
 
     d.forEach(function(y, x){
-      d3.select(id+" g").selectAll(".nodes")
+      g.selectAll(".nodes")
         .data(y).enter()
         .append("svg:circle").attr("class", "serie"+series)
         .attr('r', cfg.radius)


### PR DESCRIPTION
These explicitly broke r2d3 support, presumably because Sizzle is less forgiving than the selectors in proper d3-supported browsers.
