### PR TITLE
Added D3 as a bower dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,10 @@
 {
   "name": "radar-chart-d3",
   "version": "1.2.0",
-  "main": ["src/radar-chart.js", "src/radar-chart.css"],
+  "main": [
+    "src/radar-chart.js",
+    "src/radar-chart.css"
+  ],
   "description": "Radar chart based on D3",
   "license": "Apache",
   "ignore": [
@@ -9,7 +12,7 @@
     "**/*.txt"
   ],
   "dependencies": {
+    "d3": "~3.5.5"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
bower.json misses the d3 dependency, this PR adds that dependency and "bower_components" to the gitignore