### PR TITLE
Update radar-chart.js

### DIFF
--- a/src/radar-chart.js
+++ b/src/radar-chart.js
@@ -26,7 +26,7 @@ var RadarChart = {
   chart: function() {
     // default config
     var cfg = Object.create(RadarChart.defaultConfig);
-    var toolip;
+    var tooltip;
     function setTooltip(msg){
       if(msg == false){
         tooltip.classed("visible", 0);


### PR DESCRIPTION
Relabel a mislabel variable. It was "toolip", is now "tooltip"