### PR TITLE
Avoid division by zero error when all values are zeroes

### DIFF
--- a/src/radar-chart.js
+++ b/src/radar-chart.js
@@ -83,6 +83,8 @@ var RadarChart = {
           return d3.max(d.axes, function(o){ return o.value; });
         }));
         maxValue -= cfg.minValue;
+	if (maxValue === 0)
+		maxValue = 1;
 
         var allAxis = data[0].axes.map(function(i, j){ return {name: i.axis, xOffset: (i.xOffset)?i.xOffset:0, yOffset: (i.yOffset)?i.yOffset:0}; });
         var total = allAxis.length;


### PR DESCRIPTION
If all values to put on the chart are zero, then the size of the largest
"circle axis" is maxValue. But if the user did not supply a value via
configuration option, maxValue remains 0, which causes division by zero.

Set maxValue to 1 in such case. It has no affect on the chart as this
happens only when all values are zeroes.

Closes #3 .